### PR TITLE
Add chapter seeking buttons

### DIFF
--- a/webui-page/index.html
+++ b/webui-page/index.html
@@ -91,6 +91,17 @@
       </div>
     </div>
 
+    <div onClick="send('add_chapter', '-1')" class="button left blue">
+      <div class="content icon-content">
+        <i class="fas fa-step-backward"></i>
+      </div>
+    </div>
+    <div onClick="send('add_chapter', '1')" class="button right blue">
+      <div class="content icon-content">
+        <i class="fas fa-step-forward"></i>
+      </div>
+    </div>
+
     <div onClick="send('playlist_prev')" class="button left blue">
       <div class="content icon-content">
         <i class="fas fa-fast-backward"></i>

--- a/webui.lua
+++ b/webui.lua
@@ -137,6 +137,14 @@ local commands = {
 
   cycle_audio_device = function()
     return pcall(mp.command, "cycle_values audio-device " .. options.audio_devices)
+  end,
+
+  add_chapter = function(num)
+    local valid, msg = validate_number_param(num)
+    if not valid then
+      return true, false, msg
+    end
+    return pcall(mp.command, 'add chapter '..num)
   end
 }
 


### PR DESCRIPTION
Additionally to seeking and skipping files, seeking chapters is useful
too. Users might want to quickly navigate to where they left off in a
full-length movie, or skip repeating intro/outro sections of TV series.