### PR TITLE
Add buttons for volume handling

### DIFF
--- a/webui-page/index.html
+++ b/webui-page/index.html
@@ -91,6 +91,17 @@
       </div>
     </div>
 
+    <div onClick="send('add_volume', '-3')" class="button left blue">
+      <div class="content icon-content">
+        <i class="fas fa-volume-down"></i>
+      </div>
+    </div>
+    <div onClick="send('add_volume', '3')" class="button right blue">
+      <div class="content icon-content">
+        <i class="fas fa-volume-up"></i>
+      </div>
+    </div>
+
     <div onClick="send('playlist_prev')" class="button left blue">
       <div class="content icon-content">
         <i class="fas fa-fast-backward"></i>


### PR DESCRIPTION
While the clickable bar is great for quickly achieving big jumps in
volume, small adjustments are hard to make on small screen devices such
as smartphones.

To help users with this problem, add buttons for volume handling in
reasonable yet small increments (number chosen by fair dice roll).