### PR TITLE
feat(chapters): display chapter info and handle missing chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ information about the error.
 ``` json
 {
     "filename": "big_buck_bunny_1080p_stereo.ogg",
+    "chapter": 0,            # <-- current chapter
+    "chapters": 0,           # <-- chapters count
     "duration": 596,         # <-- seconds
     "position": 122,         # <-- seconds
     "pause": true,

--- a/webui-page/index.html
+++ b/webui-page/index.html
@@ -67,6 +67,10 @@
           <td>Audio-delay:</td>
           <td id="audio-delay"></td>
         </tr>
+        <tr id="chapterInfo">
+          <td>Chapter:</td>
+          <td id="chapter"></td>
+        </tr>
       </table>
     </div>
 
@@ -105,12 +109,12 @@
       </div>
     </div>
 
-    <div onClick="send('add_chapter', '-1')" class="button left blue">
+    <div onClick="send('add_chapter', '-1')" class="button left blue chapterButton chapterButtonSub">
       <div class="content icon-content">
         <i class="fas fa-step-backward"></i>
       </div>
     </div>
-    <div onClick="send('add_chapter', '1')" class="button right blue">
+    <div onClick="send('add_chapter', '1')" class="button right blue chapterButton chapterButtonAdd">
       <div class="content icon-content">
         <i class="fas fa-step-forward"></i>
       </div>

--- a/webui-page/webui.css
+++ b/webui-page/webui.css
@@ -60,6 +60,11 @@ h3 {
   font-size: 150px;
 }
 
+.button.disabled, .button.disabled:hover, .button.disabled:active {
+  filter: brightness(30%);
+  cursor: auto;
+}
+
 .button:hover {
   filter: brightness(50%);
 }

--- a/webui-page/webui.js
+++ b/webui-page/webui.js
@@ -325,6 +325,34 @@ function playlist_loop_cycle() {
   }
 }
 
+function setChapter(chapters, chapter) {
+  var chapterButtons = document.getElementsByClassName('chapterButton');
+  var chapterAddButtons = document.getElementsByClassName('chapterButtonAdd');
+  var chapterSubButtons = document.getElementsByClassName('chapterButtonSub');
+  var chapterTd = document.getElementById('chapter');
+  var chapterInfo = document.getElementById('chapterInfo');
+  if (chapters === 0) {
+    [].slice.call(chapterButtons).forEach(function (div) {
+      div.onclick = null;
+      div.classList.add('disabled');
+    });
+    chapterTd.innerText = "0/0";
+    chapterInfo.style.display = "none";
+  } else {
+    [].slice.call(chapterAddButtons).forEach(function (div) {
+      div.onclick = function() {send('add_chapter', '1')};
+      div.classList.remove('disabled');
+    });
+    [].slice.call(chapterSubButtons).forEach(function (div) {
+      div.onclick = function() {send('add_chapter', '-1')};
+      div.classList.remove('disabled');
+    });
+    chapterTd.innerText = chapter + 1 + "/" + chapters;
+    chapterInfo.style.display = "";
+  }
+
+}
+
 function setLoop(loopFile, loopPlaylist) {
   var loopButton = document.getElementsByClassName('playlistLoopButton');
   var html = '<i class="fas fa-redo-alt"></i>';
@@ -365,6 +393,7 @@ function handleStatusResponse(json) {
   setVolumeSlider(json['volume'], json['volume-max']);
   setLoop(json["loop-file"], json["loop-playlist"]);
   setFullscreenButton(json['fullscreen']);
+  setChapter(json['chapters'], json['chapter']);
   populatePlaylist(json['playlist'], json['pause']);
   if ('mediaSession' in navigator) {
     setupNotification();

--- a/webui.lua
+++ b/webui.lua
@@ -335,8 +335,14 @@ local function build_status_response()
     track_list = mp.get_property("track-list") or '',
     fullscreen = tostring(mp.get_property_native("fullscreen")) or '',
     loop_file = mp.get_property("loop-file") or '',
-    loop_playlist = mp.get_property("loop-playlist") or ''
+    loop_playlist = mp.get_property("loop-playlist") or '',
+    chapters = mp.get_property("chapters") or '',
+    chapter = 0
   }
+
+  if values.chapters ~= "0" then
+    values.chapter = mp.get_property("chapter") or ''
+  end
 
   -- We need to check if the value is available.
   -- If the file just started playing, mp-functions return nil for a short time.
@@ -355,6 +361,8 @@ local function build_status_response()
   end
 
   return '{"audio-delay":'..values.audio_delay:sub(1, -4)..',' ..
+          '"chapter":' ..values.chapter..',' ..
+          '"chapters":' ..values.chapters..',' ..
           '"duration":'..round(values.duration)..',' ..
           '"filename":"'..values.filename..'",' ..
           '"fullscreen":'..values.fullscreen..',' ..


### PR DESCRIPTION
Thsi commit adds the following features:

 - add `chapter` and `chapters` to the status response
 - if chapters are available, diplay info in top table
 - if no chapters are available, disable chapter seeking buttons