### PR TITLE
feat(status): do not round time and volume values

### DIFF
--- a/webui-page/index.html
+++ b/webui-page/index.html
@@ -84,7 +84,7 @@
     </div>
 
     <div class="slidecontainer">
-      <input type="range" min="0" max="130" value="100" step="1" class="slider" id="mediaVolume" title="volSlider">
+      <input type="range" min="0" max="130" value="100" step=".1" class="slider" id="mediaVolume" title="volSlider">
       <div class="sliderInfoContainer sliderVolume">
         <div class="left sliderVolume"><i class="fas fa-volume-down"></i></div>
         <div class="sliderCenter" id="volume"></div>


### PR DESCRIPTION
This commit refactors the way the status response json is built. It now
uses `mp.utils.format_json()`.

Additionally, the preparation of the data is made more readable and the
rounding of certain values has been removed.