### PR TITLE
feat(audio): add "audio-support" to status response

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ information about the error.
     "fullscreen": false,
     "loop-file": "no",       # <-- `no`, `inf` or integer
     "loop-playlist": "no",   # <-- `no`, `inf`, `force` or integer
-    "metadata": {},          # <-- All metadata available to MPV
-    "track-list": [          # <-- All available video, audio and sub tracks
+    "metadata": {},          # <-- all metadata available to MPV
+    "track-list": [          # <-- all available video, audio and sub tracks
         {
             "id": 1,
             "type": "video",
@@ -210,7 +210,8 @@ information about the error.
     ],
     "volume": 64,
     "volume-max": 130,
-    "playlist": [            # <-- All files in the current playlist
+    "audio-support": true,   # <-- is set to `false` if only the `auto` audio device is found by mpv
+    "playlist": [            # <-- all files in the current playlist
         {
             "filename": "Videos/big_buck_bunny_1080p_stereo.ogg",
             "current": true,

--- a/webui.lua
+++ b/webui.lua
@@ -317,9 +317,18 @@ local function log_line(request, code, length)
     clientip..' - - ['..time..'] "'..path..'" '..code..' '..length..' "'..referer..'" "'..agent..'"')
 end
 
+local function is_audio_supported()
+  devices = mp.get_property_native('audio-device-list')
+  if devices[1].name == "auto" and not devices[2] then
+    return false
+  end
+  return true
+end
+
 local function build_status_response()
   local values = {
     ["audio-delay"] = mp.get_property_osd("audio-delay") or '',
+    ["audio-support"] = is_audio_supported(),
     chapter = mp.get_property_native("chapter") or 0,
     chapters = mp.get_property_native("chapters") or '',
     duration = mp.get_property("duration") or '',

--- a/webui.lua
+++ b/webui.lua
@@ -344,12 +344,6 @@ local function build_status_response()
     end
   end
 
-  for _, value in pairs({"duration", "position", "remaining", "volume", "volume_max"}) do
-    if values[value] ~= nil then
-      values[value] = values[value]
-    end
-  end
-
   for _, value in pairs({"audio-delay", "sub-delay"}) do
     if values[value] ~= nil then
       values[value] = tonumber(values[value]:sub(1, -4))
@@ -535,8 +529,11 @@ local function init_servers()
 end
 
 if options.audio_devices == '' then
-  for _, device in pairs(mp.get_property_native("audio-device-list")) do
-    options.audio_devices = options.audio_devices .. ' ' .. device['name']
+  for name, _ in pairs(audio_device_list) do
+    if not options.audio_devices == '' then
+      options.audio_devices = options.audio_devices .. ' '
+    end
+    options.audio_devices = options.audio_devices .. name
   end
 end
 


### PR DESCRIPTION
This commit adds a new key "audio-support" to the status response json.

It is `false` if the only audio device found by mpv is `auto`. As this
can be subject to change, it gets reevaluated on every `/status`
request.

Related to #27