### PR TITLE
feat(auth): make htpasswd path configurable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def mpv_instance(request):
 
 @pytest.fixture(scope="class")
 def htpasswd():
-    file = Path("/app/.htpasswd")
+    file = Path("/tmp/.htpasswd")
     file.open("w").write("user:secret")
 
     yield file

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -293,13 +293,24 @@ def test_disablers(mpv_instance, v4_works, v6_works):
 
 
 @pytest.mark.parametrize(
-    "credentials,status_code",
-    [(None, 401), (("user", "wrong"), 401), (("user", "secret"), 200)],
+    "mpv_instance,auth,status_code",
+    [
+        (get_script_opts("htpasswd_path", "/tmp/.htpasswd"), None, 401,),
+        (
+            get_script_opts("htpasswd_path", "/tmp/.htpasswd"),
+            HTTPBasicAuth("user", "wrong"),
+            401,
+        ),
+        (
+            get_script_opts("htpasswd_path", "/tmp/.htpasswd"),
+            HTTPBasicAuth("user", "secret"),
+            200,
+        ),
+        (get_script_opts("htpasswd_path", "/app/.does-not-exist"), None, 200,),
+    ],
+    indirect=["mpv_instance"],
 )
-def test_auth(htpasswd, mpv_instance, credentials, status_code):
-    auth = None
-    if credentials:
-        auth = HTTPBasicAuth(*credentials)
+def test_auth(htpasswd, mpv_instance, auth, status_code):
     resp = requests.get(get_uri("api/status"), auth=auth)
     assert resp.status_code == status_code
 

--- a/webui.lua
+++ b/webui.lua
@@ -20,7 +20,8 @@ local options = {
   ipv4 = true,
   ipv6 = true,
   audio_devices = '',
-  static_dir = script_path() .. "webui-page"
+  static_dir = script_path() .. "webui-page",
+  htpasswd_path = "",
 }
 read_options(options, "webui")
 
@@ -542,9 +543,13 @@ local function listen(server, passwd)
   return
 end
 
-local function get_passwd()
-  if file_exists(script_path()..".htpasswd") then
-    return lines_from(script_path()..".htpasswd")
+local function get_passwd(path)
+  if path ~= nil then
+    if file_exists(path) then
+      return lines_from(path)
+    else
+      mp.msg.error("Error: Provided .htpasswd could not be found!")
+    end
   end
 end
 
@@ -574,7 +579,7 @@ if options.disable then
   return
 end
 
-local passwd = get_passwd()
+local passwd = get_passwd(options.htpasswd_path)
 local servers = init_servers()
 
 if next(servers) == nil then


### PR DESCRIPTION
This commit implements a new option `htpasswd_path`. This allows for
setting a custom path to the `.htpasswd` file.

BREAKING CHANGE: .htpasswd file is not auto-detected anymore. This
change is needed, because there are users that have the webui installed
through a package manager. This makes adding the file to the directory
where `webui.lua` cumbersome.