### PR TITLE
docs: improve htpasswd error message & documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,17 @@ Example:
 webui-htpasswd_path="/path/to/file"
 ```
 
+Relative paths are searched relative to the program's current working directory,
+so stick to absolute paths all the time.
+
+Shortcuts to your homedir like `~/` are not supported.
+
 ### Authentication
 There is a very simple implementation of
 [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
 
-It can be enabled by providing the htpasswd file via the [htpasswd_path](#htpasswd_path) option (it does not need to be
-called `htpasswd`).
+It can be enabled by providing the htpasswd file via the [htpasswd_path](#htpasswd_path) option.
+The file does not need to be named `htpasswd`.
 
 The provided file needs to contain data in the following format:
 

--- a/webui.lua
+++ b/webui.lua
@@ -573,7 +573,7 @@ local function get_passwd(path)
     if file_exists(path) then
       return lines_from(path)
     else
-      msg = "Provided .htpasswd could not be found!"
+      msg = "Provided htpasswd_path \"" .. path .. "\" could not be found!"
       mp.msg.error("Error: " .. msg)
       message = function() mp.osd_message(MSG_PREFIX .. msg .. "\nwebui is disabled.", 5) end
       mp.register_event("file-loaded", message)


### PR DESCRIPTION
Showing the raw string ".htpasswd" makes it seem like that's the file
that was searched.  Use the option name instead and include the user
setting directly to make it clear.