### PR TITLE
feat: lower refresh rate when page is not active

### DIFF
--- a/webui-page/webui.js
+++ b/webui-page/webui.js
@@ -507,8 +507,24 @@ function setupNotification() {
   }
 }
 
-status();
-setInterval(function(){status();}, 1000);
+// Toggle between high-refresh when active, but low-refresh when backgrounded.
+var refreshInterval;
+var nextPeriodicRefresh;
+function schedulePeriodicStatus() {
+  if (nextPeriodicRefresh) {
+    clearTimeout(nextPeriodicRefresh);
+  }
+
+  refreshInterval = document.hidden ? 10000 : 1000;
+  nextPeriodicRefresh = setTimeout(refreshStatus, refreshInterval);
+}
+function refreshStatus() {
+  status();
+  schedulePeriodicStatus();
+}
+
+document.addEventListener('visibilitychange', refreshStatus, false);
+refreshStatus();
 
 // prevent zoom-in on double-click
 // https://stackoverflow.com/questions/37808180/disable-viewport-zooming-ios-10-safari/38573198#38573198


### PR DESCRIPTION
Refreshing every second is a bit wasteful when the page is in the
background.  Use the new Page Lifecycle API to detect when it is
active and flip between refresh rates accordingly.