### PR TITLE
feat: update mediaSession playback state & position info

### DIFF
--- a/webui-page/webui.js
+++ b/webui-page/webui.js
@@ -362,6 +362,10 @@ document.getElementById("mediaVolume").oninput = function() {
 function setPlayPause(value) {
   var playPause = document.getElementsByClassName('playPauseButton');
 
+  if ('mediaSession' in navigator) {
+    navigator.mediaSession.playbackState = value ? 'paused' : 'playing';
+  }
+
   // var playPause = document.getElementById("playPause");
   if (value) {
     [].slice.call(playPause).forEach(function (div) {
@@ -454,6 +458,11 @@ function handleStatusResponse(json) {
   populatePlaylist(json['playlist'], json['pause']);
   if ('mediaSession' in navigator) {
     setupNotification();
+    navigator.mediaSession.setPositionState({
+      duration: json['duration'],
+      playbackRate: json['speed'],
+      position: json['position'],
+    });
   }
 }
 


### PR DESCRIPTION
These were never populated so clients had to assume details leading
to weird behavior: Chrome would just default to a length of 5sec and
then keep looping that range over & over.