### PR TITLE
fix: do not capture modified shortcuts

### DIFF
--- a/webui-page/webui.js
+++ b/webui-page/webui.js
@@ -283,6 +283,13 @@ var keyboardBindings = [
 ];
 
 window.onkeydown = function(e) {
+  // We have no shortcuts below that use these combos, so don't capture them.
+  // We allow Shift key as some keyboards require that to trigger the keys.
+  // For example, a US QWERTY uses Shift+/ to get ?.
+  if (e.altKey || e.ctrlKey || e.metaKey) {
+    return;
+  }
+
   for (let i = 0; i < keyboardBindings.length; i++) {
     const binding = keyboardBindings[i];
     if (e.keyCode === binding.code || e.key === binding.key) {


### PR DESCRIPTION
The keyboard shortcuts are simple keypresses like "f", not more
complicated shortcuts like Alt+f or Ctrl+f.  Do not capture those
as the browser often has its own extended bindings.