### PR TITLE
fix(frontend): fix fast touches

### DIFF
--- a/webui-page/webui.css
+++ b/webui-page/webui.css
@@ -9,6 +9,7 @@ body {
   background-color: #000000;
   color: var(--main-fg-color);
   margin: 30px;
+  touch-action: manipulation;
 }
 
 h1, h2, h3 {

--- a/webui-page/webui.js
+++ b/webui-page/webui.js
@@ -674,14 +674,3 @@ function refreshStatus() {
 
 document.addEventListener('visibilitychange', refreshStatus, false);
 refreshStatus();
-
-// prevent zoom-in on double-click
-// https://stackoverflow.com/questions/37808180/disable-viewport-zooming-ios-10-safari/38573198#38573198
-var lastTouchEnd = 0;
-document.addEventListener('touchend', function (event) {
-  var now = (new Date()).getTime();
-  if (now - lastTouchEnd <= 300) {
-    event.preventDefault();
-  }
-  lastTouchEnd = now;
-}, false);


### PR DESCRIPTION
This commit fixes a regression from
90a3c992e9f7223bf13d024440bf1ea03aab02ba. After a button click, the next
click would not be registered before a delay of 300 ms.

We're reverting 90a3c992e9f7223bf13d024440bf1ea03aab02ba and add
`touch-action: manipulation;` to `body {}`. This provides the same
functionality without causing this problem.

90a3c992e9f7223bf13d024440bf1ea03aab02ba was implemented with safari in
mind. I don't know if the solution chosen here works on safari, but at
least it doesn't break.