### PR TITLE
fix(css): prevent linebreaks in the repeat button

### DIFF
--- a/webui-page/webui.css
+++ b/webui-page/webui.css
@@ -59,6 +59,7 @@ h3 {
   color: var(--main-bg-color);
   cursor: pointer;
   font-size: 150px;
+  white-space: nowrap;
 }
 
 .button-x3 {


### PR DESCRIPTION
This commit disables linebreaks on buttons. This is mainly because of
the repeat button, that consists of up to two characters.

This solution is not perfect, as it can shift button sizes on change of
the repeat property.

The proper solution would be to find/create icons for `no repeat`,
`repeat one`, `repeat all`.