### PR TITLE
fix(api): refactor request handling; fix `Allow` header

### DIFF
--- a/tests/snapshots/snap_tests.py
+++ b/tests/snapshots/snap_tests.py
@@ -168,8 +168,8 @@ snapshots["test_status 1"] = {
         {"active": False, "description": "Default (sndio)", "name": "sndio"},
     ],
     "chapter": 0,
-    "chapters": 0,
     "chapter-list": [],
+    "chapters": 0,
     "duration": 6.024,
     "filename": "01 - dummy.mp3",
     "fullscreen": False,
@@ -218,7 +218,7 @@ snapshots["test_status 1"] = {
             "type": "audio",
         }
     ],
-    "webui-version": "2.1.0",
     "volume": 0,
     "volume-max": 130,
+    "webui-version": "2.1.0",
 }

--- a/tests/snapshots/snap_tests.py
+++ b/tests/snapshots/snap_tests.py
@@ -6,6 +6,158 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["TestsRequests.test_post_wrong_args[add-&-foo] 1"] = {
+    "message": "Parameter name contains invalid characters"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[add-foo-&] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[add_audio_delay-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[add_chapter-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[add_sub_delay-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[add_volume-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[cycle-&-foo] 1"] = {
+    "message": "Parameter name contains invalid characters"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[cycle-foo-&] 1"] = {
+    "message": 'Cycle paramater is not "up" or "down"'
+}
+
+snapshots["TestsRequests.test_post_wrong_args[loadfile-None-None] 1"] = {
+    "message": "No url provided!"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[loadfile-http://foo-invalid] 1"] = {
+    "message": "Invalid mode: 'foo'"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[loop_file-&-None] 1"] = {
+    "message": "Invalid parameter!"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[loop_file-None-None] 1"] = {
+    "message": "Invalid parameter!"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[loop_playlist-&-None] 1"] = {
+    "message": "Invalid parameter!"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[multiply-&-23] 1"] = {
+    "message": "Parameter name contains invalid characters"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[multiply-23-&] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[multiply-23-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_jump-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_jump-None-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_move-&-23] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_move-23-&] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_move-23-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_move_up-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_move_up-None-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_remove-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[playlist_remove-None-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[seek-None-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[seek-g-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[set-&-foo] 1"] = {
+    "message": "Parameter name contains invalid characters"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[set-foo- ] 1"] = {
+    "message": "Parameter value contains invalid characters"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[set_audio_delay-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[set_position-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[set_position-None-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[set_sub_delay-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[set_volume-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[speed_adjust-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[speed_set-&-None] 1"] = {
+    "message": "Parameter needs to be an integer or float"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[toggle-&-None] 1"] = {
+    "message": "Parameter name contains invalid characters"
+}
+
+snapshots["TestsRequests.test_post_wrong_args[toggle-None-None] 1"] = {
+    "message": "Parameter name contains invalid characters"
+}
+
 snapshots["test_status 1"] = {
     "audio-delay": 0,
     "audio-devices": [

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -134,6 +134,60 @@ class TestsRequests:
 
     @staticmethod
     @pytest.mark.parametrize(
+        "endpoint,arg,arg2",
+        [
+            ("seek", "g", None),
+            ("seek", None, None),
+            ("add", "&", "foo"),
+            ("add", "foo", "&"),
+            ("cycle", "&", "foo"),
+            ("cycle", "foo", "&"),
+            ("multiply", "&", "23"),
+            ("multiply", "23", "&"),
+            ("multiply", "23", None),
+            ("set", "&", "foo"),
+            ("set", "foo", " "),
+            ("toggle", "&", None),
+            ("toggle", None, None),
+            ("set_position", "&", None),
+            ("set_position", None, None),
+            ("playlist_jump", "&", None),
+            ("playlist_jump", None, None),
+            ("playlist_remove", "&", None),
+            ("playlist_remove", None, None),
+            ("playlist_move", "&", "23"),
+            ("playlist_move", "23", "&"),
+            ("playlist_move", "23", None),
+            ("playlist_move_up", "&", None),
+            ("playlist_move_up", None, None),
+            ("loop_file", "&", None),
+            ("loop_file", None, None),
+            ("loop_playlist", "&", None),
+            ("add_volume", "&", None),
+            ("set_volume", "&", None),
+            ("add_sub_delay", "&", None),
+            ("set_sub_delay", "&", None),
+            ("add_audio_delay", "&", None),
+            ("set_audio_delay", "&", None),
+            ("speed_set", "&", None),
+            ("speed_adjust", "&", None),
+            ("add_chapter", "&", None),
+            ("loadfile", None, None),
+            ("loadfile", "http://foo", "invalid"),
+        ],
+    )
+    def test_post_wrong_args(mpv_instance, snapshot, endpoint, arg, arg2):
+        send(endpoint, arg=arg, arg2=arg2, expect=400)
+        api = f"api/{endpoint}"
+        for a in [arg, arg2]:
+            if a is not None:
+                api += f"/{a}"
+        response = requests.post(get_uri(api))
+        assert response.status_code == 400
+        snapshot.assert_match(response.json())
+
+    @staticmethod
+    @pytest.mark.parametrize(
         "endpoint,arg,position",
         [("seek", "1", 1.008979), ("set_position", "2", 2.0)],
     )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -329,12 +329,27 @@ class TestsRequests:
 
     @staticmethod
     @pytest.mark.parametrize(
-        "method",
-        ["head", "patch", "not_a_valid_http_method"],
+        "endpoint,method,expected",
+        [
+            ("api/status", "head", "GET"),
+            ("api/status", "patch", "GET"),
+            ("api/status", "post", "GET"),
+            ("api/status", "not_a_valid_http_method", "GET"),
+            ("webui.js", "head", "GET"),
+            ("webui.js", "patch", "GET"),
+            ("webui.js", "post", "GET"),
+            ("webui.js", "not_a_valid_http_method", "GET"),
+            ("api/play", "head", "POST"),
+            ("api/play", "patch", "POST"),
+            ("api/play", "get", "POST"),
+            ("api/play", "not_a_valid_http_method", "POST"),
+        ],
     )
-    def test_not_allowed_methods(mpv_instance, method):
-        resp = requests.request(method, f"{get_uri('api/status')}")
+    def test_not_allowed_methods(mpv_instance, endpoint, method, expected):
+        resp = requests.request(method, f"{get_uri(endpoint)}")
         assert resp.status_code == 405
+        assert "Allow" in resp.headers
+        assert resp.headers["Allow"] == expected
 
 
 def test_loadfile(mpv_instance):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -73,6 +73,11 @@ class TestsRequests:
                 "application/xml; charset=UTF-8",
             ),
             (
+                "static/favicons/site.webmanifest",
+                200,
+                "application/manifest+json; charset=UTF-8",
+            ),
+            (
                 "static/fontawesome-free-5.0.2/css/fontawesome-all.min.css",
                 200,
                 "text/css; charset=UTF-8",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -329,20 +329,35 @@ class TestsRequests:
 
     @staticmethod
     @pytest.mark.parametrize(
+        "endpoint,expected",
+        [
+            ("api/status", "GET,OPTIONS"),
+            ("webui.js", "GET,OPTIONS"),
+            ("api/play", "POST,OPTIONS"),
+        ],
+    )
+    def test_options(mpv_instance, endpoint, expected):
+        resp = requests.options(f"{get_uri(endpoint)}")
+        assert resp.status_code == 204
+        assert "Allow" in resp.headers
+        assert resp.headers["Allow"] == expected
+
+    @staticmethod
+    @pytest.mark.parametrize(
         "endpoint,method,expected",
         [
-            ("api/status", "head", "GET"),
-            ("api/status", "patch", "GET"),
-            ("api/status", "post", "GET"),
-            ("api/status", "not_a_valid_http_method", "GET"),
-            ("webui.js", "head", "GET"),
-            ("webui.js", "patch", "GET"),
-            ("webui.js", "post", "GET"),
-            ("webui.js", "not_a_valid_http_method", "GET"),
-            ("api/play", "head", "POST"),
-            ("api/play", "patch", "POST"),
-            ("api/play", "get", "POST"),
-            ("api/play", "not_a_valid_http_method", "POST"),
+            ("api/status", "head", "GET,OPTIONS"),
+            ("api/status", "patch", "GET,OPTIONS"),
+            ("api/status", "post", "GET,OPTIONS"),
+            ("api/status", "not_a_valid_http_method", "GET,OPTIONS"),
+            ("webui.js", "head", "GET,OPTIONS"),
+            ("webui.js", "patch", "GET,OPTIONS"),
+            ("webui.js", "post", "GET,OPTIONS"),
+            ("webui.js", "not_a_valid_http_method", "GET,OPTIONS"),
+            ("api/play", "head", "POST,OPTIONS"),
+            ("api/play", "patch", "POST,OPTIONS"),
+            ("api/play", "get", "POST,OPTIONS"),
+            ("api/play", "not_a_valid_http_method", "POST,OPTIONS"),
         ],
     )
     def test_not_allowed_methods(mpv_instance, endpoint, method, expected):

--- a/webui.lua
+++ b/webui.lua
@@ -389,7 +389,7 @@ local commands = {
   end,
 
   loadfile = function(uri, mode)
-    if uri == nil or type(uri) ~= "string" then
+    if uri == "" or type(uri) ~= "string" then
       return true, false, "No url provided!"
     end
     if mode ~= nil and

--- a/webui.lua
+++ b/webui.lua
@@ -771,9 +771,11 @@ local function call_endpoint(endpoint, req_method, request)
         allowed = allowed .. "," .. method
       end
     end
-    return allowed
+    return allowed .. ",OPTIONS"
   end
-  if endpoint[req_method] == nil then
+  if req_method == "OPTIONS" then
+    return response(204, "plain", "", {Allow = get_allowed(endpoint)})
+  elseif endpoint[req_method] == nil then
     return response(
             405,
             "plain",
@@ -801,8 +803,10 @@ local function handle_request(request, passwd)
 
   if request.method == "GET" then
     return handle_static_get(request.path)
+  elseif file_exists(options.static_dir .. "/" .. request.path) and request.method == "OPTIONS" then
+    return response(204, "plain", "", {Allow = "GET,OPTIONS"})
   elseif file_exists(options.static_dir .. "/" .. request.path) then
-    return response(405, "plain", "Error: Method not allowed", {Allow = "GET"})
+    return response(405, "plain", "Error: Method not allowed", {Allow = "GET,OPTIONS"})
   end
   return response(404, "plain", "Error: Requested URL /"..request.path.." not found", {})
 end

--- a/webui.lua
+++ b/webui.lua
@@ -42,7 +42,7 @@ local function validate_number_param(param)
 end
 
 local function validate_name_param(param)
-  if not string.match(param, '^[a-z0-9/-]+$') then
+  if not string.match(param, '^[a-z0-9_/-]+$') then
     return false, 'Parameter name contains invalid characters'
   else
     return true, nil

--- a/webui.lua
+++ b/webui.lua
@@ -432,7 +432,7 @@ local function get_content_type(file_type)
   elseif file_type == 'mp3' then
     return 'audio/mpeg'
   elseif file_type == 'webmanifest' then
-    return 'application/manifest+json'
+    return 'application/manifest+json; charset=UTF-8'
   end
 end
 

--- a/webui.lua
+++ b/webui.lua
@@ -123,378 +123,6 @@ local function get_audio_devices_list()
   return devices_list
 end
 
-
-local commands = {
-  play = function()
-    return pcall(mp.set_property_bool, "pause", false)
-  end,
-
-  pause = function()
-    return pcall(mp.set_property_bool, "pause", true)
-  end,
-
-  toggle_pause = function()
-    local curr = mp.get_property_bool("pause")
-    return pcall(mp.set_property_bool, "pause", not curr)
-  end,
-
-  fullscreen = function()
-    local curr = mp.get_property_bool("fullscreen")
-    return pcall(mp.set_property_bool, "fullscreen", not curr)
-  end,
-
-  seek = function(t)
-    local valid, msg = validate_number_param(t)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', "seek", t)
-  end,
-
-  add = function(name, value)
-    local valid, msg = validate_name_param(name)
-    if not valid then
-      return true, false, msg
-    end
-    if value ~= nil and value ~= '' then
-      local valid, msg = validate_number_param(value)
-      if not valid then
-        return true, false, msg
-      end
-      return pcall(mp.commandv, 'osd-msg', 'add', name, value)
-    else
-      return pcall(mp.commandv, 'osd-msg', 'add', name)
-    end
-  end,
-
-  cycle = function(name, value)
-    local valid, msg = validate_name_param(name)
-    if not valid then
-      return true, false, msg
-    end
-    if value ~= nil and value ~= '' then
-      local valid, msg = validate_cycle_param(value)
-      if not valid then
-        return true, false, msg
-      end
-      return pcall(mp.commandv, 'osd-msg', 'cycle', name, value)
-    else
-      return pcall(mp.commandv, 'osd-msg', 'cycle', name)
-    end
-  end,
-
-  multiply = function(name, value)
-    local valid, msg = validate_name_param(name)
-    if not valid then
-      return true, false, msg
-    end
-    local valid, msg = validate_number_param(value)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'multiply', name, value)
-  end,
-
-  set = function(name, value)
-    local valid, msg = validate_name_param(name)
-    if not valid then
-      return true, false, msg
-    end
-    local valid, msg = validate_value_param(value)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'set', name, value)
-  end,
-
-  toggle = function(name)
-    local valid, msg = validate_name_param(name)
-    if not valid then
-      return true, false, msg
-    end
-    local curr = mp.get_property_bool(name)
-    return pcall(mp.set_property_bool, name, not curr)
-  end,
-
-  set_position = function(t)
-    local valid, msg = validate_number_param(t)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', "seek", t, "absolute")
-  end,
-
-  playlist_prev = function()
-    local position = tonumber(mp.get_property("time-pos") or 0)
-    if position > 1 then
-      return pcall(mp.commandv, 'osd-msg', "seek", -position)
-    else
-      return pcall(mp.commandv, 'osd-msg', "playlist-prev")
-    end
-  end,
-
-  playlist_next = function()
-    return pcall(mp.commandv, 'osd-msg', "playlist-next")
-  end,
-
-  playlist_jump = function(p)
-    local valid, msg = validate_number_param(p)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.set_property('playlist-pos', p))
-  end,
-
-  playlist_remove = function(p)
-    local valid, msg = validate_number_param(p)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv('playlist-remove', p))
-  end,
-
-  playlist_move = function(s, t)
-    args = {s, t}
-    for count = 1, 2 do
-      local valid, msg = validate_number_param(args[count])
-      if not valid then
-        return true, false, msg
-      end
-    end
-    return pcall(mp.commandv('playlist-move', s, t))
-  end,
-
-  playlist_move_up = function(p)
-    local valid, msg = validate_number_param(p)
-    if not valid then
-      return true, false, msg
-    end
-    if p - 1 >= 0 then
-      return pcall(mp.commandv('playlist-move', p, p - 1))
-    else
-      return true, true, true
-    end
-  end,
-
-  playlist_shuffle = function()
-    return pcall(mp.commandv('osd-msg', 'playlist-shuffle'))
-  end,
-
-  loop_file = function(mode)
-    local valid, msg = validate_loop_param(mode, {"inf", "no"})
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.set_property('loop-file', mode))
-  end,
-
-  loop_playlist = function(mode)
-    local valid, msg = validate_loop_param(mode, {"inf", "no", "force"})
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.set_property('loop-playlist', mode))
-  end,
-
-  add_volume = function(v)
-    local valid, msg = validate_number_param(v)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'add', 'volume', v)
-  end,
-
-  set_volume = function(v)
-    local valid, msg = validate_number_param(v)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'set', 'volume', v)
-  end,
-
-  add_sub_delay = function(sec)
-    local valid, msg = validate_number_param(sec)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'add', 'sub-delay', sec)
-  end,
-
-  set_sub_delay = function(sec)
-    local valid, msg = validate_number_param(sec)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'set', 'sub-delay', sec)
-  end,
-
-  add_audio_delay = function(sec)
-    local valid, msg = validate_number_param(sec)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'add', 'audio-delay', sec)
-  end,
-
-  set_audio_delay = function(sec)
-    local valid, msg = validate_number_param(sec)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'set', 'audio-delay', sec)
-  end,
-
-  cycle_sub = function()
-    return pcall(mp.commandv, 'osd-msg', "cycle", "sub")
-  end,
-
-  cycle_audio = function()
-    return pcall(mp.commandv, 'osd-msg', "cycle", "audio")
-  end,
-
-  cycle_audio_device = function()
-    local audio_devices_list = get_audio_devices_list()
-    return pcall(mp.commandv, "osd-msg", "cycle_values", "audio-device", unpack(audio_devices_list))
-  end,
-
-  speed_set = function(speed)
-    if speed == '' then
-      speed = '1'
-    end
-    local valid, msg = validate_number_param(speed)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'set', 'speed', speed)
-  end,
-
-  speed_adjust = function(amount)
-    local valid, msg = validate_number_param(amount)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'multiply', 'speed', amount)
-  end,
-
-  add_chapter = function(num)
-    local valid, msg = validate_number_param(num)
-    if not valid then
-      return true, false, msg
-    end
-    return pcall(mp.commandv, 'osd-msg', 'add', 'chapter', num)
-  end,
-
-  quit = function()
-    return pcall(mp.commandv, 'osd-msg', 'quit')
-  end,
-
-  loadfile = function(uri, mode)
-    if uri == "" or type(uri) ~= "string" then
-      return true, false, "No url provided!"
-    end
-    if mode ~= nil and
-            mode ~= "" and
-            mode ~= "replace" and
-            mode ~= "append" and
-            mode ~= "append-play"
-    then
-      print('Invalid mode: "' .. mode .. '"')
-      return true, false, "Invalid mode: '" .. mode .. "'"
-    end
-    if mode == nil or mode == "" then
-      mode = "replace"
-    end
-    return pcall(mp.commandv, "loadfile", uri, mode)
-  end
-}
-
-local function get_content_type(file_type)
-  if file_type == 'html' then
-    return 'text/html; charset=UTF-8'
-  elseif file_type == 'plain' then
-    return 'text/plain; charset=UTF-8'
-  elseif file_type == 'json' then
-    return 'application/json; charset=UTF-8'
-  elseif file_type == 'js' then
-    return 'application/javascript; charset=UTF-8'
-  elseif file_type == 'png' then
-    return 'image/png'
-  elseif file_type == 'ico' then
-    return 'image/x-icon'
-  elseif file_type == 'svg' then
-    return 'image/svg+xml'
-  elseif file_type == 'xml' then
-    return 'application/xml; charset=UTF-8'
-  elseif file_type == 'css' then
-    return 'text/css; charset=UTF-8'
-  elseif file_type == 'woff2' then
-    return 'font/woff2; charset=UTF-8'
-  elseif file_type == 'mp3' then
-    return 'audio/mpeg'
-  elseif file_type == 'webmanifest' then
-    return 'application/manifest+json; charset=UTF-8'
-  end
-end
-
-local function header(code, content_type, content_length)
-  local status_headers = {
-    [200] = "OK",
-    [400] = "Bad Request",
-    [401] = 'Unauthorized\nWWW-Authenticate: Basic realm="Simple MPV WebUI',
-    [404] = "Not Found",
-    [405] = "Method Not Allowed\nAllow: GET,POST",
-    [503] = "Service Unavailable"
-  }
-
-  return "HTTP/1.1 " .. tostring(code) .. " " .. status_headers[code] ..
-         '\nAccess-Control-Allow-Origin: *\nContent-Type: ' .. content_type ..
-         '\nContent-Length: ' .. content_length .. '\nServer: simple-mpv-webui\nConnection: close\n\n'
-end
-
-local function file_exists(file)
-  local f = io.open(file, "rb")
-  if f then f:close() end
-  return f ~= nil
-end
-
-local function lines_from(file)
-  local lines = {}
-  for line in io.lines(file) do
-    lines[#lines + 1] = line
-  end
-  return lines
-end
-
-local function read_file(path)
-  local file = io.open(path, "rb")
-  if not file then return nil end
-  local content = file:read "*a"
-  file:close()
-  return content
-end
-
-local function log_line(request, code, length)
-  if not options.logging then
-    return
-  end
-
-  local clientip = request.clientip or '-'
-  local user = request.user or '-'
-  local path = request.request or '-'
-  local referer = request.referer or '-'
-  local agent = request.agent or '-'
-  local time = os.date('%d/%b/%Y:%H:%M:%S %z', os.time())
-  mp.msg.info(
-    clientip..' - '..user..' ['..time..'] "'..path..'" '..code..' '..length..' "'..referer..'" "'..agent..'"')
-end
-
-local function log_osd(text)
-  if not options.osd_logging then
-    return
-  end
-  mp.osd_message(MSG_PREFIX .. text, 5)
-end
-
 local function build_status_response()
   local values = {
     ["audio-delay"] = mp.get_property_osd("audio-delay") or '',
@@ -551,43 +179,546 @@ local function build_status_response()
   return utils.format_json(values)
 end
 
-local function handle_post(path)
-  local components = string.gmatch(path, "[^/]+")
-  local api_prefix = components()
-  if api_prefix ~= 'api' then
-    return 404, get_content_type('plain'), "Error: Requested URL /"..path.." not found"
-  end
-  local command = components()
-  local param1 = components() or ""
-  local param2 = components() or ""
-
-  param1 = url.unescape(param1)
-  param2 = url.unescape(param2)
-
-  local f = commands[command]
-  if f ~= nil then
-    local _, success, ret = f(param1, param2)
-    if success and ret == nil then
-      ret = "success"
-    end
-    response_json = utils.format_json({message = ret})
-    if success then
-      return 200, get_content_type('json'), response_json
-    else
-      return 400, get_content_type('json'), response_json
-    end
-  else
-    return 404, get_content_type('plain'), "Error: Requested URL /"..path.." not found"
+local function get_content_type(file_type)
+  if file_type == 'html' then
+    return 'text/html; charset=UTF-8'
+  elseif file_type == 'plain' then
+    return 'text/plain; charset=UTF-8'
+  elseif file_type == 'json' then
+    return 'application/json; charset=UTF-8'
+  elseif file_type == 'js' then
+    return 'application/javascript; charset=UTF-8'
+  elseif file_type == 'png' then
+    return 'image/png'
+  elseif file_type == 'ico' then
+    return 'image/x-icon'
+  elseif file_type == 'svg' then
+    return 'image/svg+xml'
+  elseif file_type == 'xml' then
+    return 'application/xml; charset=UTF-8'
+  elseif file_type == 'css' then
+    return 'text/css; charset=UTF-8'
+  elseif file_type == 'woff2' then
+    return 'font/woff2; charset=UTF-8'
+  elseif file_type == 'mp3' then
+    return 'audio/mpeg'
+  elseif file_type == 'webmanifest' then
+    return 'application/manifest+json; charset=UTF-8'
   end
 end
 
-local function handle_status_get()
-  local json = build_status_response()
-  if not json then
-    return 503, get_content_type('plain'), "Error: Not ready to handle requests."
-  else
-    return 200, get_content_type("json"), json
+local function headers(code, content_type, content_length, add_headers)
+  if add_headers == nil then
+    add_headers = {}
   end
+
+  custom_headers = ""
+  for key,value in pairs(add_headers) do
+    custom_headers = custom_headers .. "\n" .. key .. ": " .. value
+  end
+
+  local status_headers = {
+    [200] = "OK",
+    [204] = "No Content",
+    [400] = "Bad Request",
+    [401] = 'Unauthorized\nWWW-Authenticate: Basic realm="Simple MPV WebUI"',
+    [404] = "Not Found",
+    [405] = "Method Not Allowed",
+    [503] = "Service Unavailable"
+  }
+
+  return "HTTP/1.1 " .. tostring(code) .. " " .. status_headers[code] ..
+         "\nAccess-Control-Allow-Origin: *\nContent-Type: " .. content_type ..
+         "\nContent-Length: " .. content_length .. custom_headers .. "\nServer: simple-mpv-webui\nConnection: close\n\n"
+end
+
+local function response(code, file_type, content, add_headers)
+  local content_type = get_content_type(file_type)
+  return {
+    code = code,
+    content_length = #content,
+    content = content,
+    content_type = content_type,
+    add_headers = add_headers,
+    headers = headers(code, content_type, #content, add_headers),
+  }
+end
+
+local function handle_post(success, msg)
+  if success and msg == nil then
+    msg = "success"
+  end
+  response_json = utils.format_json({message = msg})
+  if success then
+    return response(200, 'json', response_json, {})
+  end
+  return response(400, "json", response_json, {})
+end
+
+local endpoints = {
+  ["api/status"] = {
+    GET = function(_)
+      local json = build_status_response()
+      if not json then
+        return response(503, "plain", "Error: Not ready to handle requests.", {})
+      else
+        return response(200, "json", json, {})
+      end
+    end
+  },
+
+  ["api/play"] = {
+    POST = function(_)
+      local _, success, ret = pcall(mp.set_property_bool, "pause", false)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/pause"] = {
+    POST = function(_)
+      local _, success, ret = pcall(mp.set_property_bool, "pause", true)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/toggle_pause"] = {
+    POST = function(_)
+      local curr = mp.get_property_bool("pause")
+      local _, success, ret = pcall(mp.set_property_bool, "pause", not curr)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/fullscreen"] = {
+    POST = function(_)
+      local curr = mp.get_property_bool("fullscreen")
+      local _, success, ret = pcall(mp.set_property_bool, "fullscreen", not curr)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/seek"] = {
+    POST = function(request)
+      local t = request.param1
+      local valid, msg = validate_number_param(t)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', "seek", t)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/add"] = {
+    POST = function(request)
+      local name, value = request.param1, request.param2
+      local valid, msg = validate_name_param(name)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      if value ~= nil and value ~= '' then
+        local valid, msg = validate_number_param(value)
+        if not valid then
+          return response(400, "json", utils.format_json({message = msg}), {})
+        end
+        local _, success, ret = pcall(mp.commandv, 'osd-msg', 'add', name, value)
+        return handle_post(success, ret)
+      else
+        local _, success, ret = pcall(mp.commandv, 'osd-msg', 'add', name)
+        return handle_post(success, ret)
+      end
+    end
+  },
+
+  ["api/cycle"] = {
+    POST = function(request)
+      local name, value = request.param1, request.param2
+      local valid, msg = validate_name_param(name)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      if value ~= nil and value ~= '' then
+        local valid, msg = validate_cycle_param(value)
+        if not valid then
+          return response(400, "json", utils.format_json({message = msg}), {})
+        end
+        local _, success, ret = pcall(mp.commandv, 'osd-msg', 'cycle', name, value)
+        return handle_post(success, ret)
+      else
+        local _, success, ret = pcall(mp.commandv, 'osd-msg', 'cycle', name)
+        return handle_post(success, ret)
+      end
+    end
+  },
+
+  ["api/multiply"] = {
+    POST = function(request)
+      local name, value = request.param1, request.param2
+      local valid, msg = validate_name_param(name)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local valid, msg = validate_number_param(value)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'multiply', name, value)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/set"] = {
+    POST = function(request)
+      local name, value = request.param1, request.param2
+      local valid, msg = validate_name_param(name)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local valid, msg = validate_value_param(value)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'set', name, value)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/toggle"] = {
+    POST = function(request)
+      local name = request.param1
+      local valid, msg = validate_name_param(name)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local curr = mp.get_property_bool(name)
+      local _, success, ret = pcall(mp.set_property_bool, name, not curr)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/set_position"] = {
+    POST = function(request)
+      local t = request.param1
+      local valid, msg = validate_number_param(t)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', "seek", t, "absolute")
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/playlist_prev"] = {
+    POST = function(_)
+      local position = tonumber(mp.get_property("time-pos") or 0)
+      if position > 1 then
+        local _, success, ret = pcall(mp.commandv, 'osd-msg', "seek", -position)
+        return handle_post(success, ret)
+      else
+        local _, success, ret = pcall(mp.commandv, 'osd-msg', "playlist-prev")
+        return handle_post(success, ret)
+      end
+    end
+  },
+
+  ["api/playlist_next"] = {
+    POST = function(_)
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', "playlist-next")
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/playlist_jump"] = {
+    POST = function(request)
+      local p = request.param1
+      local valid, msg = validate_number_param(p)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.set_property('playlist-pos', p))
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/playlist_remove"] = {
+    POST = function(request)
+      local p = request.param1
+      local valid, msg = validate_number_param(p)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv('playlist-remove', p))
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/playlist_move"] = {
+    POST = function(request)
+      local s, t = request.param1, request.param2
+      args = {s, t}
+      for count = 1, 2 do
+        local valid, msg = validate_number_param(args[count])
+        if not valid then
+          return response(400, "json", utils.format_json({message = msg}), {})
+        end
+      end
+      local _, success, ret = pcall(mp.commandv('playlist-move', s, t))
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/playlist_move_up"] = {
+    POST = function(request)
+      local p = request.param1
+      local valid, msg = validate_number_param(p)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      if p - 1 >= 0 then
+        local _, success, ret = pcall(mp.commandv('playlist-move', p, p - 1))
+        return handle_post(success, ret)
+      else
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+    end
+  },
+
+  ["api/playlist_shuffle"] = {
+    POST = function(_)
+      local _, success, ret = pcall(mp.commandv('osd-msg', 'playlist-shuffle'))
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/loop_file"] = {
+    POST = function(request)
+      local mode = request.param1
+      local valid, msg = validate_loop_param(mode, {"inf", "no"})
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.set_property('loop-file', mode))
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/loop_playlist"] = {
+    POST = function(request)
+      local mode = request.param1
+      local valid, msg = validate_loop_param(mode, {"inf", "no", "force"})
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.set_property('loop-playlist', mode))
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/add_volume"] = {
+    POST = function(request)
+      local v = request.param1
+      local valid, msg = validate_number_param(v)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'add', 'volume', v)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/set_volume"] = {
+    POST = function(request)
+      local v = request.param1
+      local valid, msg = validate_number_param(v)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'set', 'volume', v)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/add_sub_delay"] = {
+    POST = function(request)
+      local sec = request.param1
+      local valid, msg = validate_number_param(sec)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'add', 'sub-delay', sec)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/set_sub_delay"] = {
+    POST = function(request)
+      local sec = request.param1
+      local valid, msg = validate_number_param(sec)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'set', 'sub-delay', sec)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/add_audio_delay"] = {
+    POST = function(request)
+      local sec = request.param1
+      local valid, msg = validate_number_param(sec)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'add', 'audio-delay', sec)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/set_audio_delay"] = {
+    POST = function(request)
+      local sec = request.param1
+      local valid, msg = validate_number_param(sec)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'set', 'audio-delay', sec)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/cycle_sub"] = {
+    POST = function(_)
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', "cycle", "sub")
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/cycle_audio"] = {
+    POST = function(_)
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', "cycle", "audio")
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/cycle_audio_device"] = {
+    POST = function(_)
+      local audio_devices_list = get_audio_devices_list()
+      local _, success, ret = pcall(mp.commandv, "osd-msg", "cycle_values", "audio-device", unpack(audio_devices_list))
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/speed_set"] = {
+    POST = function(request)
+      local speed = request.param1
+      if speed == '' then
+        speed = '1'
+      end
+      local valid, msg = validate_number_param(speed)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'set', 'speed', speed)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/speed_adjust"] = {
+    POST = function(request)
+      local amount = request.param1
+      local valid, msg = validate_number_param(amount)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'multiply', 'speed', amount)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/add_chapter"] = {
+    POST = function(request)
+      local num = request.param1
+      local valid, msg = validate_number_param(num)
+      if not valid then
+        return response(400, "json", utils.format_json({message = msg}), {})
+      end
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'add', 'chapter', num)
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/quit"] = {
+    POST = function(_)
+      local _, success, ret = pcall(mp.commandv, 'osd-msg', 'quit')
+      return handle_post(success, ret)
+    end
+  },
+
+  ["api/loadfile"] = {
+    POST = function(request)
+      local uri, mode = request.param1, request.param2
+      if uri == "" or type(uri) ~= "string" then
+        return response(400, "json", utils.format_json({message = "No url provided!"}), {})
+      end
+      if mode ~= nil and
+              mode ~= "" and
+              mode ~= "replace" and
+              mode ~= "append" and
+              mode ~= "append-play"
+      then
+        return response(400, "json", utils.format_json({message = "Invalid mode: '" .. mode .. "'"}), {})
+      end
+      if mode == nil or mode == "" then
+        mode = "replace"
+      end
+      local _, success, ret = pcall(mp.commandv, "loadfile", uri, mode)
+      return handle_post(success, ret)
+    end
+  }
+}
+
+local function file_exists(file)
+  local f = io.open(file, "rb")
+  if f then f:close() end
+  return f ~= nil
+end
+
+local function lines_from(file)
+  local lines = {}
+  for line in io.lines(file) do
+    lines[#lines + 1] = line
+  end
+  return lines
+end
+
+local function read_file(path)
+  local file = io.open(path, "rb")
+  if not file then return nil end
+  local content = file:read "*a"
+  file:close()
+  return content
+end
+
+local function log_line(request, code, length)
+  if not options.logging then
+    return
+  end
+
+  local clientip = request.clientip or '-'
+  local user = request.user or '-'
+  local path = request.request or '-'
+  local referer = request.referer or '-'
+  local agent = request.agent or '-'
+  local time = os.date('%d/%b/%Y:%H:%M:%S %z', os.time())
+  mp.msg.info(
+    clientip..' - '..user..' ['..time..'] "'..path..'" '..code..' '..length..' "'..referer..'" "'..agent..'"')
+end
+
+local function log_osd(text)
+  if not options.osd_logging then
+    return
+  end
+  mp.osd_message(MSG_PREFIX .. text, 5)
 end
 
 local function handle_static_get(path)
@@ -597,11 +728,10 @@ local function handle_static_get(path)
 
   local content = read_file(options.static_dir .. "/" .. path)
   local extension = path:match("[^.]+$") or ""
-  local content_type = get_content_type(extension)
-  if content == nil or content_type == nil then
-    return 404, get_content_type('plain'), "Error: Requested URL /"..path.." not found"
+  if content == nil or extension == nil then
+    return response(404, "plain", "Error: Requested URL /"..path.." not found", {})
   else
-    return 200, content_type, content
+    return response(200, extension, content, {})
   end
 end
 
@@ -617,31 +747,77 @@ local function is_authenticated(request, passwd)
   return false
 end
 
+local function parse_path(raw_path)
+  local path_components = string.gmatch(raw_path, "[^/]+")
+  local path = path_components()
+  if path == 'api' then
+    path = path .. "/" .. path_components()
+  end
+  local param1 = path_components() or ""
+  local param2 = path_components() or ""
+
+  param1 = url.unescape(param1)
+  param2 = url.unescape(param2)
+  return path, param1, param2
+end
+
+local function call_endpoint(endpoint, req_method, request)
+  local function get_allowed(ep)
+    local allowed = ""
+    for method in pairs(ep) do
+      if allowed == "" then
+        allowed = method
+      else
+        allowed = allowed .. "," .. method
+      end
+    end
+    return allowed
+  end
+  if endpoint[req_method] == nil then
+    return response(
+            405,
+            "plain",
+            "Error: Method not allowed",
+            {Allow = get_allowed(endpoint)}
+    )
+  end
+  return endpoint[req_method](request)
+end
+
 local function handle_request(request, passwd)
   if passwd ~= nil then
     if not is_authenticated(request, passwd) then
-      return 401, get_content_type('plain'), "Authentication required."
+      return response(401, "plain", "Authentication required.", {})
     end
   else
     request.user = nil
     request.password = nil
   end
-  if request.method == "POST" then
-    return handle_post(request.path)
 
-  elseif request.method == "GET" then
-    if request.path == "api/status" or request.path == "api/status/" then
-      return handle_status_get()
-    else
-      return handle_static_get(request.path)
-    end
-  else
-    return 405, get_content_type('plain'), "Error: Method not allowed"
+  local endpoint = endpoints[request.path]
+  if endpoint ~= nil then
+    return call_endpoint(endpoint, request.method, request)
   end
+
+  if request.method == "GET" then
+    return handle_static_get(request.path)
+  elseif file_exists(options.static_dir .. "/" .. request.path) then
+    return response(405, "plain", "Error: Method not allowed", {Allow = "GET"})
+  end
+  return response(404, "plain", "Error: Requested URL /"..request.path.." not found", {})
+end
+
+local function new_request()
+  return {
+    agent = "",
+    referer = "",
+    user = nil,
+    password = nil,
+  }
 end
 
 local function parse_request(connection)
-  local request = {}
+  local request = new_request()
   request.clientip = connection:getpeername()
   local line = connection:receive()
   if line == nil or line == "" then
@@ -670,6 +846,9 @@ local function parse_request(connection)
     end
     line = connection:receive()
   end
+  if request.method == "POST" then
+    request.path, request.param1, request.param2 = parse_path(request.path)
+  end
   return request
 end
 
@@ -679,9 +858,7 @@ local function listen(server, passwd)
     return
   end
 
-  local code = 400
-  local content_type = get_content_type("plain")
-  local content = "Bad request!"
+  local response = response(400, "plain", "Bad request!", {})
 
   local success, request = pcall(parse_request, connection)
 
@@ -689,13 +866,13 @@ local function listen(server, passwd)
     if request == nil then
       return
     end
-    code, content_type, content = handle_request(request, passwd)
+    response = handle_request(request, passwd)
   end
 
-  connection:send(header(code, content_type, #content))
-  connection:send(content)
+  connection:send(response.headers)
+  connection:send(response.content)
   connection:close()
-  log_line(request, code, #content)
+  log_line(request, response.code, response.content_length)
   return
 end
 

--- a/webui.lua
+++ b/webui.lua
@@ -128,8 +128,8 @@ local function build_status_response()
     ["audio-delay"] = mp.get_property_osd("audio-delay") or '',
     ["audio-devices"] = get_audio_devices(),
     chapter = mp.get_property_native("chapter") or 0,
-    chapters = mp.get_property_native("chapters") or '',
     ["chapter-list"] = mp.get_property_native("chapter-list") or '',
+    chapters = mp.get_property_native("chapters") or '',
     duration = mp.get_property_native("duration") or '',
     filename = mp.get_property('filename') or '',
     fullscreen = mp.get_property_native("fullscreen"),
@@ -143,9 +143,9 @@ local function build_status_response()
     speed = mp.get_property_native('speed') or '',
     ["sub-delay"] = mp.get_property_osd("sub-delay") or '',
     ["track-list"] = mp.get_property_native("track-list") or '',
-    ["webui-version"] = VERSION,
     volume = mp.get_property_native("volume") or '',
-    ["volume-max"] = mp.get_property_native("volume-max") or ''
+    ["volume-max"] = mp.get_property_native("volume-max") or '',
+    ["webui-version"] = VERSION,
   }
 
   for _, value in pairs({"fullscreen", "loop-file", "loop-playlist", "pause"}) do


### PR DESCRIPTION
This commit refactores the handling of requests in the API. All
endpoints are added as functions to a table. A new `response` table is
introduced. Every endpoint function returns such response.
This allows for more generic request handling, while offering even more
customizability per request. As a side effect, the `Allow:` header now
contains the correct methods instead of hardcoded `GET,POST`.